### PR TITLE
Fixed flaky test - bugfix - testing

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -23,8 +23,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -327,7 +327,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Use 2 Threads for 2 data-tables
     // Different segments are assigned to each set of DataTables. This is necessary to simulate scenarios where
     // certain segments may completely be pruned on one server but not the other.
-    Map<ServerRoutingInstance, DataTable> dataTableMap = new HashMap<>();
+    Map<ServerRoutingInstance, DataTable> dataTableMap = new LinkedHashMap<>();
     try {
       // For multi-threaded BrokerReduceService, we cannot reuse the same data-table
       byte[] serializedResponse1 = instanceResponse1.toDataTable().toBytes();


### PR DESCRIPTION
The assertion checking the size each DataTable failed with the non dex tool. For context, the non dex tools is a tool that helps find flaky tests through overriding standard datatypes with it's own implementation which shuffles data outputs if the state of the output is not deterministic.

The root cause of the issue was that the DataTable was implented with a HashMap leading to non determistic behavior when viewed as the items inside the HashMap were not sorted and order could not be guaranteed. Since the items inside the DataTable were shuffled by the non dex tool, the sizes of the expected DataTable did not match with the actual. 

My fix was to replace the HashMap with a LinkedHashMap as a LinkedHashMap should guarantee the order of the values inside according to the JavaDocs.